### PR TITLE
fix debugs and docs

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -33,10 +33,6 @@ jobs:
       run: sbt test
     - name: Generate JAR
       run: sbt assembly
-    - name: Debug
-      run: ls ./target/
-    - name: Debug 2
-      run: ls ./target/scala-3.6.4
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ You have to click on each workflow and grant permissions on each
 of the nested Workflows.
 
 # The solution
-`java -jar dbgremlin --user-email "your-colleage@email.com" --job-id 1234567897`
+`java -jar dbgremlin.jar --user-email "your-colleague@email.com" --job-id 1234567897`
 
 A single command recursively sets permissions on each of the nested Workflows.
+The `jar` is available on the [actions artifacts](https://github.com/JoaquinIglesiasTurina/dbgremlin/actions).
+Click on any successful run, and you can download the jar there.
 
 # Prerequisites
 You need to have [Databricks CLI configured](https://learn.microsoft.com/en-us/azure/databricks/dev-tools/cli/tutorial)


### PR DESCRIPTION
removes debug prints from build yaml and documents where the `jar` can be found